### PR TITLE
Remove debug symbols from final executable

### DIFF
--- a/kin_logfmt/CMakeLists.txt
+++ b/kin_logfmt/CMakeLists.txt
@@ -9,7 +9,7 @@ find_package(Boost REQUIRED COMPONENTS system)
 include_directories(${Boost_INCLUDE_DIRS})
 link_directories(${Boost_LIBRARY_DIRS})
 
-add_definitions(-std=c++14 -g -O2 -pthread -fopenmp -Wall -Wextra)
+add_definitions(-std=c++14 -O2 -pthread -fopenmp -Wall -Wextra)
 
 include_directories(./include
         ../cpp-logfmt/src)


### PR DESCRIPTION
The `-g` flag allows us to use gdb which is not needed when using the library elsewhere.
This removes certain optimizations among other things.
Reference: https://gcc.gnu.org/onlinedocs/gcc/Debugging-Options.html
                     https://stackoverflow.com/questions/89603/how-does-the-debugging-option-g-change-the-binary-executable