### PR TITLE
protect against message buffer overflow and add warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ request_id,
 client,
 ```
 
+Warning! Messages longer than `MAX_MSG_LENGTH` defined in logger.h (currently 5000) will be truncated and "[TRUNCATED]" appended to the end of the message.
+
 Cleanup is managed within the KinLogfmt object, so don't call delete on your loggers.
 
 ## Developing

--- a/kin_logfmt/include/logger.h
+++ b/kin_logfmt/include/logger.h
@@ -67,7 +67,7 @@ namespace kin_logfmt {
     return lhs < rhs;
   }
 
-  const int MAX_MSG_LENGTH = 500;
+  const int MAX_MSG_LENGTH = 5000; // messages longer than this will be truncated
 
 
   class Logger {
@@ -109,7 +109,7 @@ namespace kin_logfmt {
     // Override sprintf
     // Throws SprintfException if the args do not comply
     template <class ...Args>
-    static int sprintf(char *buffer, const char* format, const int arg_count, const Args&... args);
+    static int format_string(char *buffer, size_t max_length, const char* format, const int arg_count, const Args&... args);
 
     private:
 


### PR DESCRIPTION
I was running into a buffer overflow crash when trying to log a long line.  In the PR I added protection against buffer overflow by truncating the offending messages and appending a warning to the line.

To avoid confusion I also renamed the `Logger::sprintf` which was not an "overload" since it changed the meaning of the return argument.

Finally, I bumped MAX_MSG_LENGTH to 5000 since it is not the 1980s.